### PR TITLE
Fixed wreck date of loss displaying incorrectly for dates before 1848…

### DIFF
--- a/backoffice/src/Models/ViewModels/WreckView.cs
+++ b/backoffice/src/Models/ViewModels/WreckView.cs
@@ -26,7 +26,7 @@ public class WreckView : BaseEntityView
         ConstructionDetails = wreck.ConstructionDetails;
         YearConstructed = wreck.YearConstructed;
 
-        DateOfLoss = wreck.DateOfLoss;
+        DateOfLoss = wreck.DateOfLoss?.ToUniversalTime();
         InUkWaters = wreck.InUkWaters;
         IsWarWreck = wreck.IsWarWreck;
         IsAnAircraft = wreck.IsAnAircraft;

--- a/backoffice/tests/UnitTests/Model/ViewModels/WreckViewUnitTests.cs
+++ b/backoffice/tests/UnitTests/Model/ViewModels/WreckViewUnitTests.cs
@@ -1,0 +1,26 @@
+using Droits.Models.Entities;
+using Droits.Models.ViewModels;
+
+namespace Droits.Tests.UnitTests.Model.ViewModels;
+
+public class WreckViewUnitTests
+{
+    private readonly Wreck _wreck;
+    public WreckViewUnitTests()
+    {
+        _wreck = new Wreck()
+        {
+            DateOfLoss = new DateTime(1640, 1, 1),
+        };
+
+    }
+    [Fact]
+    public void ShouldReturnCorrectDateOfLoss()
+    {
+        var wreckView = new WreckView(_wreck);
+        var response = wreckView.DateOfLoss;
+        var expected = new DateTime(1640, 1, 1).ToUniversalTime();
+
+        Assert.Equal(expected, response);
+    }
+}


### PR DESCRIPTION
…. Date was showing in local time, converted to UTC in WreckView. Unit test added.