### PR TITLE
fix: Added block for unsafe access due to prototype-polluting assignment

### DIFF
--- a/webapp/api/routes/report/property-form-address.js
+++ b/webapp/api/routes/report/property-form-address.js
@@ -43,6 +43,7 @@ export default function (app) {
 
       var propertyID;
       var propertyItem;
+      
       property[rawPropertyID]['storage-address'] =
         req.body.property[rawPropertyID]['storage-address'];
 

--- a/webapp/api/routes/report/property-form-address.js
+++ b/webapp/api/routes/report/property-form-address.js
@@ -34,11 +34,16 @@ export default function (app) {
           req.body.property[rawPropertyID];
       }
 
+        const forbiddenKeys = ['__proto__', 'constructor', 'prototype'];
+        if (forbiddenKeys.includes(id)) {
+            return res.sendStatus(403);
+        }
+        
       req.session.data.property[rawPropertyID]['address-details'] = {};
 
       var propertyID;
       var propertyItem;
-
+      
       property[rawPropertyID]['storage-address'] =
         req.body.property[rawPropertyID]['storage-address'];
 

--- a/webapp/api/routes/report/property-form-address.js
+++ b/webapp/api/routes/report/property-form-address.js
@@ -35,7 +35,7 @@ export default function (app) {
       }
 
         const forbiddenKeys = ['__proto__', 'constructor', 'prototype'];
-        if (forbiddenKeys.includes(id)) {
+        if (forbiddenKeys.includes(rawPropertyID)) {
             return res.sendStatus(403);
         }
         

--- a/webapp/api/routes/report/property-form-address.js
+++ b/webapp/api/routes/report/property-form-address.js
@@ -43,7 +43,6 @@ export default function (app) {
 
       var propertyID;
       var propertyItem;
-      
       property[rawPropertyID]['storage-address'] =
         req.body.property[rawPropertyID]['storage-address'];
 

--- a/webapp/api/routes/report/property-form-image-delete.js
+++ b/webapp/api/routes/report/property-form-image-delete.js
@@ -12,6 +12,10 @@ export default function (app) {
       }
     });
 
+    const forbiddenKeys = ['__proto__', 'constructor', 'prototype'];
+    if (forbiddenKeys.includes(id)) {
+      return res.sendStatus(403);
+    }
     req.session.data.property[id].image = '';
     req.session.save();
     res.json();

--- a/webapp/api/routes/report/property-form-image-delete.js
+++ b/webapp/api/routes/report/property-form-image-delete.js
@@ -16,6 +16,7 @@ export default function (app) {
     if (forbiddenKeys.includes(id)) {
       return res.sendStatus(403);
     }
+    
     req.session.data.property[id].image = '';
     req.session.save();
     res.json();

--- a/webapp/api/routes/report/property-form-image-upload.js
+++ b/webapp/api/routes/report/property-form-image-upload.js
@@ -78,6 +78,7 @@ export default function (app) {
             if (forbiddenKeys.includes(id)) {
               return res.sendStatus(403);
             }
+            
             req.session.data.property[id].image = req.file.filename;
             req.session.data.property[id].originalFilename = req.file.originalname;
             req.session.save();

--- a/webapp/api/routes/report/property-form-image-upload.js
+++ b/webapp/api/routes/report/property-form-image-upload.js
@@ -73,7 +73,11 @@ export default function (app) {
               uploadedFilename: req.file.filename,
               originalFilename: req.file.originalname,
             };
-
+            
+            const forbiddenKeys = ['__proto__', 'constructor', 'prototype'];
+            if (forbiddenKeys.includes(id)) {
+              return res.sendStatus(403);
+            }
             req.session.data.property[id].image = req.file.filename;
             req.session.data.property[id].originalFilename = req.file.originalname;
             req.session.save();

--- a/webapp/api/routes/report/property-form.js
+++ b/webapp/api/routes/report/property-form.js
@@ -35,35 +35,25 @@ export default function (app) {
   app.post('/report/property-form-image/:prop_id', async (req, res, next) => {
     var rawPropertyID = req.params.prop_id;
 
-    if (!req.session.data.property[rawPropertyID]) {
-      req.session.data.property[rawPropertyID] =
-        req.body.property[rawPropertyID];
-    }
-    const forbiddenDescription = ['__proto__', 'constructor', 'prototype'];
-    if (forbiddenDescription.includes(rawPropertyID)) {
-      return res.sendStatus(403);
-    }
-    req.session.data.property[rawPropertyID].description =
-      req.body.property[rawPropertyID].description;
-
-    const forbiddenQuantity = ['__proto__', 'constructor', 'prototype'];
-    if (forbiddenQuantity.includes(rawPropertyID)) {
-      return res.sendStatus(403);
-    }
-    req.session.data.property[rawPropertyID]['quantity'] =
-      req.body.property[rawPropertyID].quantity;
-
-    const forbiddenBody = ['__proto__', 'constructor', 'prototype'];
-    if (forbiddenBody.includes(rawPropertyID)) {
-      return res.sendStatus(403);
-    }
-    req.session.data.property[rawPropertyID]['value-known'] =
-      req.body['value-known'];
-    
     const forbiddenKeys = ['__proto__', 'constructor', 'prototype'];
     if (forbiddenKeys.includes(rawPropertyID)) {
       return res.sendStatus(403);
     }
+    
+    if (!req.session.data.property[rawPropertyID]) {
+      req.session.data.property[rawPropertyID] =
+        req.body.property[rawPropertyID];
+    }
+    
+    req.session.data.property[rawPropertyID].description =
+      req.body.property[rawPropertyID].description;
+    
+    req.session.data.property[rawPropertyID]['quantity'] =
+      req.body.property[rawPropertyID].quantity;
+
+    req.session.data.property[rawPropertyID]['value-known'] =
+      req.body['value-known'];
+    
     req.session.data.property[rawPropertyID]['value'] =
       req.body.property[rawPropertyID].value;
 

--- a/webapp/api/routes/report/property-form.js
+++ b/webapp/api/routes/report/property-form.js
@@ -44,16 +44,12 @@ export default function (app) {
       req.session.data.property[rawPropertyID] =
         req.body.property[rawPropertyID];
     }
-    
     req.session.data.property[rawPropertyID].description =
       req.body.property[rawPropertyID].description;
-    
     req.session.data.property[rawPropertyID]['quantity'] =
       req.body.property[rawPropertyID].quantity;
-
     req.session.data.property[rawPropertyID]['value-known'] =
       req.body['value-known'];
-    
     req.session.data.property[rawPropertyID]['value'] =
       req.body.property[rawPropertyID].value;
 

--- a/webapp/api/routes/report/property-form.js
+++ b/webapp/api/routes/report/property-form.js
@@ -39,7 +39,10 @@ export default function (app) {
       req.session.data.property[rawPropertyID] =
         req.body.property[rawPropertyID];
     }
-
+    const forbiddenDescription = ['__proto__', 'constructor', 'prototype'];
+    if (forbiddenDescription.includes(rawPropertyID)) {
+      return res.status(400).send('Invalid property ID');
+    }
     req.session.data.property[rawPropertyID].description =
       req.body.property[rawPropertyID].description;
 

--- a/webapp/api/routes/report/property-form.js
+++ b/webapp/api/routes/report/property-form.js
@@ -44,6 +44,11 @@ export default function (app) {
       req.body.property[rawPropertyID].description;
     req.session.data.property[rawPropertyID]['quantity'] =
       req.body.property[rawPropertyID].quantity;
+
+    const forbiddenBody = ['__proto__', 'constructor', 'prototype'];
+    if (forbiddenBody.includes(rawPropertyID)) {
+      return res.status(400).send('Invalid property ID');
+    }
     req.session.data.property[rawPropertyID]['value-known'] =
       req.body['value-known'];
     

--- a/webapp/api/routes/report/property-form.js
+++ b/webapp/api/routes/report/property-form.js
@@ -41,28 +41,28 @@ export default function (app) {
     }
     const forbiddenDescription = ['__proto__', 'constructor', 'prototype'];
     if (forbiddenDescription.includes(rawPropertyID)) {
-      return res.status(403).send('Invalid property ID');
+      return res.sendStatus(403);
     }
     req.session.data.property[rawPropertyID].description =
       req.body.property[rawPropertyID].description;
 
     const forbiddenQuantity = ['__proto__', 'constructor', 'prototype'];
     if (forbiddenQuantity.includes(rawPropertyID)) {
-      return res.status(403).send('Invalid property ID');
+      return res.sendStatus(403);
     }
     req.session.data.property[rawPropertyID]['quantity'] =
       req.body.property[rawPropertyID].quantity;
 
     const forbiddenBody = ['__proto__', 'constructor', 'prototype'];
     if (forbiddenBody.includes(rawPropertyID)) {
-      return res.status(403).send('Invalid property ID');
+      return res.sendStatus(403);
     }
     req.session.data.property[rawPropertyID]['value-known'] =
       req.body['value-known'];
     
     const forbiddenKeys = ['__proto__', 'constructor', 'prototype'];
     if (forbiddenKeys.includes(rawPropertyID)) {
-      return res.status(403).send('Invalid property ID');
+      return res.sendStatus(403);
     }
     req.session.data.property[rawPropertyID]['value'] =
       req.body.property[rawPropertyID].value;

--- a/webapp/api/routes/report/property-form.js
+++ b/webapp/api/routes/report/property-form.js
@@ -44,6 +44,7 @@ export default function (app) {
       req.session.data.property[rawPropertyID] =
         req.body.property[rawPropertyID];
     }
+    
     req.session.data.property[rawPropertyID].description =
       req.body.property[rawPropertyID].description;
     req.session.data.property[rawPropertyID]['quantity'] =

--- a/webapp/api/routes/report/property-form.js
+++ b/webapp/api/routes/report/property-form.js
@@ -54,6 +54,7 @@ export default function (app) {
     req.session.data.property[rawPropertyID]['value'] =
       req.body.property[rawPropertyID].value;
       
+
     var property = req.session.data.property;
     var propertyID;
     var propertyItem;

--- a/webapp/api/routes/report/property-form.js
+++ b/webapp/api/routes/report/property-form.js
@@ -53,6 +53,7 @@ export default function (app) {
       req.body['value-known'];
     req.session.data.property[rawPropertyID]['value'] =
       req.body.property[rawPropertyID].value;
+      
     var property = req.session.data.property;
     var propertyID;
     var propertyItem;

--- a/webapp/api/routes/report/property-form.js
+++ b/webapp/api/routes/report/property-form.js
@@ -42,6 +42,11 @@ export default function (app) {
 
     req.session.data.property[rawPropertyID].description =
       req.body.property[rawPropertyID].description;
+
+    const forbiddenQuantity = ['__proto__', 'constructor', 'prototype'];
+    if (forbiddenQuantity.includes(rawPropertyID)) {
+      return res.status(400).send('Invalid property ID');
+    }
     req.session.data.property[rawPropertyID]['quantity'] =
       req.body.property[rawPropertyID].quantity;
 

--- a/webapp/api/routes/report/property-form.js
+++ b/webapp/api/routes/report/property-form.js
@@ -52,7 +52,6 @@ export default function (app) {
       req.body['value-known'];
     req.session.data.property[rawPropertyID]['value'] =
       req.body.property[rawPropertyID].value;
-
     var property = req.session.data.property;
     var propertyID;
     var propertyItem;

--- a/webapp/api/routes/report/property-form.js
+++ b/webapp/api/routes/report/property-form.js
@@ -44,7 +44,6 @@ export default function (app) {
       req.session.data.property[rawPropertyID] =
         req.body.property[rawPropertyID];
     }
-    
     req.session.data.property[rawPropertyID].description =
       req.body.property[rawPropertyID].description;
     req.session.data.property[rawPropertyID]['quantity'] =

--- a/webapp/api/routes/report/property-form.js
+++ b/webapp/api/routes/report/property-form.js
@@ -46,6 +46,11 @@ export default function (app) {
       req.body.property[rawPropertyID].quantity;
     req.session.data.property[rawPropertyID]['value-known'] =
       req.body['value-known'];
+    
+    const forbiddenKeys = ['__proto__', 'constructor', 'prototype'];
+    if (forbiddenKeys.includes(rawPropertyID)) {
+      return res.status(400).send('Invalid property ID');
+    }
     req.session.data.property[rawPropertyID]['value'] =
       req.body.property[rawPropertyID].value;
 

--- a/webapp/api/routes/report/property-form.js
+++ b/webapp/api/routes/report/property-form.js
@@ -53,7 +53,6 @@ export default function (app) {
       req.body['value-known'];
     req.session.data.property[rawPropertyID]['value'] =
       req.body.property[rawPropertyID].value;
-      
 
     var property = req.session.data.property;
     var propertyID;

--- a/webapp/api/routes/report/property-form.js
+++ b/webapp/api/routes/report/property-form.js
@@ -41,28 +41,28 @@ export default function (app) {
     }
     const forbiddenDescription = ['__proto__', 'constructor', 'prototype'];
     if (forbiddenDescription.includes(rawPropertyID)) {
-      return res.status(400).send('Invalid property ID');
+      return res.status(403).send('Invalid property ID');
     }
     req.session.data.property[rawPropertyID].description =
       req.body.property[rawPropertyID].description;
 
     const forbiddenQuantity = ['__proto__', 'constructor', 'prototype'];
     if (forbiddenQuantity.includes(rawPropertyID)) {
-      return res.status(400).send('Invalid property ID');
+      return res.status(403).send('Invalid property ID');
     }
     req.session.data.property[rawPropertyID]['quantity'] =
       req.body.property[rawPropertyID].quantity;
 
     const forbiddenBody = ['__proto__', 'constructor', 'prototype'];
     if (forbiddenBody.includes(rawPropertyID)) {
-      return res.status(400).send('Invalid property ID');
+      return res.status(403).send('Invalid property ID');
     }
     req.session.data.property[rawPropertyID]['value-known'] =
       req.body['value-known'];
     
     const forbiddenKeys = ['__proto__', 'constructor', 'prototype'];
     if (forbiddenKeys.includes(rawPropertyID)) {
-      return res.status(400).send('Invalid property ID');
+      return res.status(403).send('Invalid property ID');
     }
     req.session.data.property[rawPropertyID]['value'] =
       req.body.property[rawPropertyID].value;

--- a/webapp/api/routes/report/property-form.js
+++ b/webapp/api/routes/report/property-form.js
@@ -44,6 +44,7 @@ export default function (app) {
       req.session.data.property[rawPropertyID] =
         req.body.property[rawPropertyID];
     }
+
     req.session.data.property[rawPropertyID].description =
       req.body.property[rawPropertyID].description;
     req.session.data.property[rawPropertyID]['quantity'] =


### PR DESCRIPTION
## Context
Most JavaScript objects inherit the properties of the built-in Object.prototype object. Prototype pollution is a type of vulnerability in which an attacker is able to modify Object.prototype. 

## Changes
- Prevent the __proto__ property from being used as a key