### PR TITLE
refactor!: remove keypather due to security vulnerability and replace with lodash

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -45,7 +45,6 @@
         "glightbox": "^3.0.7",
         "govuk-frontend": "^4.10.0",
         "helmet": "^4.4.1",
-        "keypather": "^3.1.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.inrange": "^3.3.6",
         "lusca": "^1.7.0",
@@ -3955,24 +3954,6 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
-    "node_modules/101": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/101/-/101-1.6.3.tgz",
-      "integrity": "sha512-4dmQ45yY0Dx24Qxp+zAsNLlMF6tteCyfVzgbulvSyC7tCyd3V8sW76sS0tHq8NpcbXfWTKasfyfzU1Kd86oKzw==",
-      "dependencies": {
-        "clone": "^1.0.2",
-        "deep-eql": "^0.1.3",
-        "keypather": "^1.10.2"
-      }
-    },
-    "node_modules/101/node_modules/keypather": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/keypather/-/keypather-1.10.2.tgz",
-      "integrity": "sha512-hgomDZ+POrsgpkE7qQuSI2ffyfVLJdDLxk8spzWeR33ovNssz6jCWDOIBLEPyI8SAWcQ5njl1ignlqgMrZsGpA==",
-      "dependencies": {
-        "101": "^1.0.0"
-      }
-    },
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
@@ -4395,15 +4376,6 @@
       "dependencies": {
         "object.assign": "^4.1.4",
         "util": "^0.10.4"
-      }
-    },
-    "node_modules/assert-err": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assert-err/-/assert-err-1.1.0.tgz",
-      "integrity": "sha512-dEOsK5ngosvrne66QiI3D3nsvTesIMhiiH0tYC5sISAFFzvZza0PFxWWanNcoBX90McFTRsebVkR0ApXxtkGqA==",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
       }
     },
     "node_modules/assert/node_modules/inherits": {
@@ -5745,6 +5717,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -7185,25 +7158,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
-      "dependencies": {
-        "type-detect": "0.1.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/deep-eql/node_modules/type-detect": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-      "integrity": "sha512-5rqszGVwYgBoDkIm2oUtvkfZMQ0vk29iDMU0W2qCa3rG0vPDNczCMT4hV/bLBgLg8k8ri6+u3Zbt+S/14eMzlA==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/deepmerge": {
@@ -11768,26 +11722,6 @@
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/keypather": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/keypather/-/keypather-3.1.0.tgz",
-      "integrity": "sha512-DsxfrBVXlQihWmefW/lNvVgtzFoSoDd67mCsop7a+tK9h7ybpBF5YRUXg192GBmOc3gn4IEv3AV69HElXYuCLA==",
-      "dependencies": {
-        "101": "^1.6.2",
-        "debug": "^3.1.0",
-        "escape-string-regexp": "^1.0.5",
-        "shallow-clone": "^3.0.0",
-        "string-reduce": "^1.0.0"
-      }
-    },
-    "node_modules/keypather/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
       }
     },
     "node_modules/kind-of": {
@@ -18786,17 +18720,6 @@
         "sha.js": "bin.js"
       }
     },
-    "node_modules/shallow-clone": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "dependencies": {
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -19660,14 +19583,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/string-reduce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string-reduce/-/string-reduce-1.0.0.tgz",
-      "integrity": "sha512-Sc7/l7xG8TvJrC1+LNowFgAyW0jerj73NHPJo66ijTQCbveJ2TRHoq+mACTLzlFTO7V30ESzb23qTU6wB0VNCQ==",
-      "dependencies": {
-        "assert-err": "^1.1.0"
       }
     },
     "node_modules/string-width": {
@@ -22421,26 +22336,6 @@
     }
   },
   "dependencies": {
-    "101": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/101/-/101-1.6.3.tgz",
-      "integrity": "sha512-4dmQ45yY0Dx24Qxp+zAsNLlMF6tteCyfVzgbulvSyC7tCyd3V8sW76sS0tHq8NpcbXfWTKasfyfzU1Kd86oKzw==",
-      "requires": {
-        "clone": "^1.0.2",
-        "deep-eql": "^0.1.3",
-        "keypather": "^1.10.2"
-      },
-      "dependencies": {
-        "keypather": {
-          "version": "1.10.2",
-          "resolved": "https://registry.npmjs.org/keypather/-/keypather-1.10.2.tgz",
-          "integrity": "sha512-hgomDZ+POrsgpkE7qQuSI2ffyfVLJdDLxk8spzWeR33ovNssz6jCWDOIBLEPyI8SAWcQ5njl1ignlqgMrZsGpA==",
-          "requires": {
-            "101": "^1.0.0"
-          }
-        }
-      }
-    },
     "@ampproject/remapping": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
@@ -25449,15 +25344,6 @@
         }
       }
     },
-    "assert-err": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assert-err/-/assert-err-1.1.0.tgz",
-      "integrity": "sha512-dEOsK5ngosvrne66QiI3D3nsvTesIMhiiH0tYC5sISAFFzvZza0PFxWWanNcoBX90McFTRsebVkR0ApXxtkGqA==",
-      "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
-      }
-    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -26452,7 +26338,8 @@
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true
     },
     "co": {
       "version": "4.6.0",
@@ -27546,21 +27433,6 @@
       "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
       "dev": true,
       "requires": {}
-    },
-    "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
-      "requires": {
-        "type-detect": "0.1.1"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha512-5rqszGVwYgBoDkIm2oUtvkfZMQ0vk29iDMU0W2qCa3rG0vPDNczCMT4hV/bLBgLg8k8ri6+u3Zbt+S/14eMzlA=="
-        }
-      }
     },
     "deepmerge": {
       "version": "4.3.1",
@@ -31031,28 +30903,6 @@
       "requires": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "keypather": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/keypather/-/keypather-3.1.0.tgz",
-      "integrity": "sha512-DsxfrBVXlQihWmefW/lNvVgtzFoSoDd67mCsop7a+tK9h7ybpBF5YRUXg192GBmOc3gn4IEv3AV69HElXYuCLA==",
-      "requires": {
-        "101": "^1.6.2",
-        "debug": "^3.1.0",
-        "escape-string-regexp": "^1.0.5",
-        "shallow-clone": "^3.0.0",
-        "string-reduce": "^1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "kind-of": {
@@ -36356,14 +36206,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "shallow-clone": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "requires": {
-        "kind-of": "^6.0.2"
-      }
-    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -37078,14 +36920,6 @@
       "requires": {
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
-      }
-    },
-    "string-reduce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string-reduce/-/string-reduce-1.0.0.tgz",
-      "integrity": "sha512-Sc7/l7xG8TvJrC1+LNowFgAyW0jerj73NHPJo66ijTQCbveJ2TRHoq+mACTLzlFTO7V30ESzb23qTU6wB0VNCQ==",
-      "requires": {
-        "assert-err": "^1.1.0"
       }
     },
     "string-width": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -61,7 +61,6 @@
     "glightbox": "^3.0.7",
     "govuk-frontend": "^4.10.0",
     "helmet": "^4.4.1",
-    "keypather": "^3.1.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.inrange": "^3.3.6",
     "lusca": "^1.7.0",

--- a/webapp/utilities/addCheckedFunction.js
+++ b/webapp/utilities/addCheckedFunction.js
@@ -1,4 +1,4 @@
-import getKeypath from 'keypather/get';
+import get from 'lodash/get';
 
 // Add Nunjucks function called 'checked' to populate radios and checkboxes
 export const addCheckedFunction = (env) => {
@@ -11,8 +11,9 @@ export const addCheckedFunction = (env) => {
     // checked("field-name")
     // checked("['field-name']")
     // checked("['parent']['field-name']")
-    name = !name.match(/[.[]/g) ? `['${name}']` : name;
-    var storedValue = getKeypath(this.ctx.data, name);
+    // Convert brackets to dots for lodash get
+    const path = name.match(/[.[]/g) ? name.replace(/\['/g, '.').replace(/'\]/g, '').replace(/^\./, '') : name;
+    var storedValue = get(this.ctx.data, path);
     // Check the requested data exists
     if (storedValue === undefined) {
       return '';

--- a/webapp/utilities/addCheckedFunction.test.js
+++ b/webapp/utilities/addCheckedFunction.test.js
@@ -1,0 +1,91 @@
+import { addCheckedFunction } from './addCheckedFunction';
+
+describe('addCheckedFunction', () => {
+  let mockEnv;
+  let checkedFunction;
+  // create test environment
+  beforeEach(() => {
+    mockEnv = {
+      addGlobal: jest.fn((name, fn) => {
+        if (name === 'checked') {
+          checkedFunction = fn;
+        }
+      })
+    };
+    
+    addCheckedFunction(mockEnv);
+  });
+
+  it('registers the checked function', () => {
+    expect(mockEnv.addGlobal).toHaveBeenCalledWith('checked', expect.any(Function));
+  });
+
+  it('returns empty string when no data', () => {
+    const context = { ctx: {} };
+    expect(checkedFunction.call(context, 'test', 'value')).toBe('');
+  });
+
+  it('returns checked for exact matches', () => {
+    const context = {
+      ctx: { data: { name: 'John' } }
+    };
+    
+    expect(checkedFunction.call(context, 'name', 'John')).toBe('checked');
+    expect(checkedFunction.call(context, 'name', 'Jane')).toBe('');
+  });
+
+  it('works with checkboxes arrays', () => {
+    const context = {
+      ctx: { data: { hobbies: ['reading', 'cycling'] } }
+    };
+    
+    expect(checkedFunction.call(context, 'hobbies', 'reading')).toBe('checked');
+    expect(checkedFunction.call(context, 'hobbies', 'swimming')).toBe('');
+  });
+
+  it('handles bracket notation', () => {
+    const context = {
+      ctx: { data: { personal: { age: 25 } } }
+    };
+    
+    expect(checkedFunction.call(context, "['personal']['age']", 25)).toBe('checked');
+  });
+
+  it('handles nested brackets', () => {
+    const context = {
+      ctx: { 
+        data: { 
+          address: { 
+            uk: { postcode: 'BB5 555' } 
+          } 
+        } 
+      }
+    };
+    
+    expect(checkedFunction.call(context, "['address']['uk']['postcode']", 'BB5 555')).toBe('checked');
+  });
+
+  it('returns empty for missing fields', () => {
+    const context = {
+      ctx: { data: { name: 'John' } }
+    };
+    
+    expect(checkedFunction.call(context, 'missing', 'value')).toBe('');
+  });
+
+  it('handles different types', () => {
+    const context = {
+      ctx: { 
+        data: { 
+          count: 5,
+          active: true,
+          empty: null
+        } 
+      }
+    };
+    
+    expect(checkedFunction.call(context, 'count', 5)).toBe('checked');
+    expect(checkedFunction.call(context, 'active', true)).toBe('checked');
+    expect(checkedFunction.call(context, 'empty', null)).toBe('checked');
+  });
+});


### PR DESCRIPTION
Keypather was removed due to a critical vulnerability in its dependency, '101@1.6.3', for which no patched version is available at the time of writing. A suitable replacement has been implemented using lodash, specifically within the 'addCheckedFunction' utility. Some test cases have been added to ensure compatibility.

This change is breaking, as any downstream usage of keypather must now be updated to use the new implementation.

BREAKING CHANGE: keypather has been removed and replaced with lodash. Any code relying on keypather must be refactored accordingly.
