### PR TITLE
fix: Docker compose port in use fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Once you have these files in place, you can start the application by running `do
 
 - Instance fails to start: If you ran `docker compose up` before creating and populating the `.env.json` and `appsettings.json` files, this will cause the instance to fail. To resolve this, clean up the environment and run the command again.
 
-- Port 5000 is unavailable: If you encounter a port binding error, port `5000` is already in use. To fix this, update `your docker-compose.yml` file to use an alternative port, such as `5005` or `5010`. **WARNING: do not commit this change**
+- Port 5000 is unavailable: If you encounter a port binding error, port `5000` is already in use. To solve this, run `HOST_PORT=5005 docker compose up` (or alternative port number)
 
 ## Infrastructure-as-code
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: ./backoffice
     image: droits-backoffice
     ports:
-      - "5000:5000"
+      - "${HOST_PORT:-5000}:5000"
       - "5001:5001"
     environment:
       ASPNETCORE_Kestrel__Certificates__Default__Password: "password"


### PR DESCRIPTION
This PR addresses an issue where port `5000` might be in use in one's system.

```
Error response from daemon: ports are not available: 
exposing port TCP 0.0.0.0:5000 -> 127.0.0.1:0: listen tcp 0.0.0.0:5000: bind: address already in use
```

Instead of manually changing the `docker-compose.yaml` file, this allows port to be set at environment level, like so

`HOST_PORT=5005 docker compose up`

which is obviously less dangerous and disruptive than accidentally committing the compose file