### PR TITLE
fix(security): remove express-debug to resolve debug RegEx DoS vulnerability

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -36,7 +36,6 @@
         "dotenv-json": "^1.0.0",
         "esm": "^3.2.25",
         "express": "^4.17.1",
-        "express-debug": "^1.1.1",
         "express-session": "^1.18.2",
         "express-session-redis": "^0.2.0",
         "express-validator": "^6.9.2",
@@ -5105,6 +5104,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5639,12 +5639,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/character-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz",
-      "integrity": "sha512-DcT7xnScdoZy9nFFIjJ5uAUNCsiXzMgmNSAWK3XDXpHtlrlgmPhzYWAw/CxWCbuisIDh7xsfyJTm0lIWHknpog==",
-      "license": "MIT"
     },
     "node_modules/chardet": {
       "version": "0.7.0",
@@ -6278,23 +6272,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/connectr": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/connectr/-/connectr-0.0.6.tgz",
-      "integrity": "sha512-v2MZtAbDr+HQBL7wSm9rXKkHAU5P9dWLUM89aMT2lpPNim6LxvKp390xw7N7t40DkBqdr9zV1Oghv8tLqnJF8w==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "~0.7.2"
-      }
-    },
-    "node_modules/connectr/node_modules/debug": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-      "integrity": "sha512-EohAb3+DSHSGx8carOSKJe8G0ayV5/i609OD0J2orCkuyae7SyZSz2aoLmQF2s0Pj5gITDebwPH7GFBlqOUQ1Q==",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -7977,20 +7954,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express-debug": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/express-debug/-/express-debug-1.1.1.tgz",
-      "integrity": "sha512-zKZcF0kutJtuLxmO2uN1chiFtk+1jr7mGAQSKOK1EHPu3MKeBYeiQN0eLvosb/z0y8R6zkxY/CQk52KDrmGAGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "connectr": "0.0.6",
-        "jade": "0.29.0",
-        "xtend": "2.0.3"
-      },
-      "peerDependencies": {
-        "express": ">= 3.0.0 < 5"
-      }
-    },
     "node_modules/express-session": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
@@ -9379,12 +9342,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-promise": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
-      "integrity": "sha512-mjWH5XxnhMA8cFnDchr6qRP9S/kLntKuEfIYku+PaN1CnS8v+OG9O/BKpRCVRJvpIkgAZm0Pf5Is3iSSOILlcg==",
-      "license": "MIT"
-    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -9585,37 +9542,6 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
-    },
-    "node_modules/jade": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/jade/-/jade-0.29.0.tgz",
-      "integrity": "sha512-dWqafag/NYHYzSg+2LzFmiCux3L8ziOZx9WK1d2IU9iBEV5CJN5vHJi/yd0bNM78QBVkidt9w2NyUYQijAmh+Q==",
-      "deprecated": "Jade has been renamed to pug, please install the latest version of pug instead of jade",
-      "dependencies": {
-        "character-parser": "~1.0.0",
-        "commander": "0.6.1",
-        "mkdirp": "0.3.x",
-        "monocle": "~0.1.43",
-        "transformers": "~1.8.0"
-      },
-      "bin": {
-        "jade": "bin/jade"
-      }
-    },
-    "node_modules/jade/node_modules/commander": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-      "integrity": "sha512-0fLycpl1UMTGX257hRsu/arL/cUbcvQM4zMKwvLvzXtfdezIV4yotPS2dYtknF+NmEfWSoCEF6+hj9XLm/6hEw==",
-      "engines": {
-        "node": ">= 0.4.x"
-      }
-    },
-    "node_modules/jade/node_modules/mkdirp": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-      "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg==",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "license": "MIT"
     },
     "node_modules/jest": {
       "version": "29.7.0",
@@ -11887,6 +11813,7 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -12006,27 +11933,6 @@
       "optional": true,
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/monocle": {
-      "version": "0.1.50",
-      "resolved": "https://registry.npmjs.org/monocle/-/monocle-0.1.50.tgz",
-      "integrity": "sha512-YT0QDamTT1slZmScdnA1jhxuG24S+EvWJTUkvgp3Pe4dCehbNE9Yw4wBZYBlfmj2zcjqBux3vM2pzh1EEYxYfg==",
-      "license": "BSD",
-      "dependencies": {
-        "readdirp": "~0.2.3"
-      }
-    },
-    "node_modules/monocle/node_modules/readdirp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-0.2.5.tgz",
-      "integrity": "sha512-j3/RLxRiCZSei/4UaYaOAqHa+rQ8ZL9vpolGO9E7mLXiVTb7Fu99eTG74ZmaB/4gCGgy7Veq+U6vw8y7sKJiTw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimatch": ">=0.2.4"
-      },
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/morgan": {
@@ -15701,15 +15607,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/promise": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
-      "integrity": "sha512-OgMc+sxI3zWF8D5BJGtA0z7/IsrDy1/0cPaDv6HPpqa2fSTo7AdON5U10NbZCUeF+zCAj3PtfPE50Hf02386aA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-promise": "~1"
-      }
-    },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -17900,16 +17797,6 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
-    "node_modules/transformers": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/transformers/-/transformers-1.8.3.tgz",
-      "integrity": "sha512-7PSrTe7KFMh98C7aNSUNWSbkAx7BARex7eBGICvBD3ygaYh/+9OAkWU7qOL8iguaNxQptRdcUHOu8+YUtKbdyA==",
-      "deprecated": "Deprecated, use jstransformer",
-      "license": "MIT",
-      "dependencies": {
-        "promise": "~2.0"
-      }
-    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -18704,14 +18591,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/xtend": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.0.3.tgz",
-      "integrity": "sha512-lqevzMdAT/vO/0lZIi34SHoG06g/VsPsUV6LKRo2v3MxRyY2mya3UdZsGsaMDL5L0DU2u2/WfuDhJ+ddS1ofHw==",
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -52,7 +52,6 @@
     "dotenv-json": "^1.0.0",
     "esm": "^3.2.25",
     "express": "^4.17.1",
-    "express-debug": "^1.1.1",
     "express-session": "^1.18.2",
     "express-session-redis": "^0.2.0",
     "express-validator": "^6.9.2",

--- a/webapp/server.js
+++ b/webapp/server.js
@@ -2,7 +2,6 @@ import express from 'express';
 import bodyParser from 'body-parser';
 import nunjucks from 'nunjucks';
 import path from 'path';
-import edt from 'express-debug';
 import {
   sessionData,
   addCheckedFunction,
@@ -132,9 +131,6 @@ if (config.SERVICE_UNAVAILABLE) {
 
   // Manage session data. Assigns default values to data
   app.use(sessionData);
-
-  // Logs req.session data
-  if (env === 'development') edt(app, { panels: ['session'] });
 
 
   app.get('/', function(req, res){


### PR DESCRIPTION
**This PR resolves the below dependabot vulnerability**
debug Inefficient Regular Expression Complexity vulnerability

This has been done by removing the express-debug package - This is used once  in server.js.

All tests pass. 