### PR TITLE
feat: change webapp port to 5005 for local development through docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Once you have these files in place, you can start the application by running `do
 
 - Instance fails to start: If you ran `docker compose up` before creating and populating the `.env.json` and `appsettings.json` files, this will cause the instance to fail. To resolve this, clean up the environment and run the command again.
 
-- Port 5000 is unavailable: If you encounter a port binding error, port `5000` is already in use. To solve this, run `HOST_PORT=5005 docker compose up` (or alternative port number)
+- Port 5005 is unavailable: If you encounter a port binding error, port `5005` is already in use. To solve this, run `HOST_PORT=5002 docker compose up` (or alternative port number)
 
 ## Infrastructure-as-code
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: ./backoffice
     image: droits-backoffice
     ports:
-      - "${HOST_PORT:-5000}:5000"
+      - "${HOST_PORT:-5005}:5005"
       - "5001:5001"
     environment:
       ASPNETCORE_Kestrel__Certificates__Default__Password: "password"


### PR DESCRIPTION
This change has been made following initial difficulty setting up docker compose for local development, as port 5000 is in use on Mac devices by Launchpad. 

This changes the README, and docker-compose.yml to use the new port. 

This is for local development only, as docker compose is only used on development machines, not during the deployment.

The docker config still uses port 5000 outside of development. 