### PR TITLE
fix: Use JSON instead of application/x-www-form-urlencoded to resolve form value count 1024 limit.

### DIFF
--- a/backoffice/src/Controllers/DroitController.cs
+++ b/backoffice/src/Controllers/DroitController.cs
@@ -1,7 +1,6 @@
 #region
 
 using System.Globalization;
-using System.Text;
 using AutoMapper;
 using CsvHelper;
 using Droits.Exceptions;
@@ -147,7 +146,7 @@ public class DroitController : BaseController
 
 
     [HttpPost]
-    public async Task<IActionResult> Save(DroitForm form)
+    public async Task<IActionResult> Save([FromBody] DroitForm form)
     {
         try
         {
@@ -198,24 +197,7 @@ public class DroitController : BaseController
         }
         catch ( Exception e )
         {
-            // Debugging: Log to CloudWatch
-            HttpContext.Request.EnableBuffering();
-            var rawBody = string.Empty;
-            using (var reader = new StreamReader(HttpContext.Request.Body, Encoding.UTF8, leaveOpen: true))
-            {
-                rawBody = await reader.ReadToEndAsync();
-                HttpContext.Request.Body.Position = 0;
-            }
-            
-            var formKeys = HttpContext.Request.HasFormContentType
-                ? string.Join(", ", HttpContext.Request.Form.Keys)
-                : "(no form fields)";
-            _logger.LogError($"[DEBUG] ContentType: {HttpContext.Request.ContentType}");
-            _logger.LogError($"[DEBUG] FormKeys: {formKeys}");
-            _logger.LogError($"[DEBUG] RawBody: {rawBody}");
-            _logger.LogError($"[DEBUG] Raw body length: {rawBody.Length} characters");
-            _logger.LogError($"[DEBUG] ModelState Errors: {string.Join(" | ", ModelState.Values.SelectMany(v => v.Errors).Select(modelError => modelError.ErrorMessage))}");
-            _logger.LogError($"Error saving droit: {e}");
+            _logger.LogError("Error saving droit: {Exception}", e);
             return BadRequest(new { error = $"Error saving droit - {e.Message}" });
         }
  

--- a/backoffice/src/Converters/FlexibleBooleanConverter.cs
+++ b/backoffice/src/Converters/FlexibleBooleanConverter.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Droits.Converters;
+
+public class FlexibleBooleanConverter : JsonConverter<bool>
+{
+    public override bool Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.String:
+            {
+                var str = reader.GetString();
+                if (string.IsNullOrWhiteSpace(str))
+                    return false;
+                if (bool.TryParse(str, out var result))
+                    return result;
+                break;
+            }
+            case JsonTokenType.True:
+                return true;
+            case JsonTokenType.False:
+                break;
+        }
+
+        return false;
+    }
+
+    public override void Write(Utf8JsonWriter writer, bool value, JsonSerializerOptions options)
+    {
+        writer.WriteBooleanValue(value);
+    }
+}

--- a/backoffice/src/Converters/FlexibleNullableBooleanConverter.cs
+++ b/backoffice/src/Converters/FlexibleNullableBooleanConverter.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Droits.Converters;
+
+public class FlexibleNullableBooleanConverter : JsonConverter<bool?>
+{
+    public override bool? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.String:
+            {
+                var str = reader.GetString();
+                if (string.IsNullOrWhiteSpace(str))
+                    return null;
+                if (bool.TryParse(str, out var result))
+                    return result;
+                break;
+            }
+            case JsonTokenType.True:
+                return true;
+            case JsonTokenType.False:
+                return false;
+        }
+
+        return null;
+    }
+
+    public override void Write(Utf8JsonWriter writer, bool? value, JsonSerializerOptions options)
+    {
+        if (value.HasValue) writer.WriteBooleanValue(value.Value);
+        else writer.WriteNullValue();
+    }
+}

--- a/backoffice/src/Program.cs
+++ b/backoffice/src/Program.cs
@@ -1,7 +1,10 @@
 
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Amazon.Runtime;
 using Amazon.S3;
 using Droits.Clients;
+using Droits.Converters;
 using Droits.Data;
 using Droits.Data.Mappers.Submission;
 using Droits.Data.Mappers.Imports;
@@ -50,7 +53,14 @@ builder.Services.AddControllersWithViews(options =>
 
         options.Filters.Add(new AuthorizeFilter(policy));
     })
-    .AddRazorRuntimeCompilation().AddMicrosoftIdentityUI().AddSessionStateTempDataProvider();
+    .AddRazorRuntimeCompilation().AddMicrosoftIdentityUI().AddSessionStateTempDataProvider()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+        options.JsonSerializerOptions.Converters.Add(new FlexibleBooleanConverter());
+        options.JsonSerializerOptions.Converters.Add(new FlexibleNullableBooleanConverter());
+    });
+    
 
 var awsOptions = builder.Configuration.GetAWSOptions();
 

--- a/backoffice/src/Views/Droit/Edit.cshtml
+++ b/backoffice/src/Views/Droit/Edit.cshtml
@@ -50,7 +50,7 @@
     </li>
 </ul>
 
-<form class="form-horizontal js-droit-form" asp-action="Save" enctype="multipart/form-data" method="POST">
+<form id="droitMultiPartForm" class="form-horizontal js-droit-form" asp-action="Save" enctype="multipart/form-data" method="POST">
 @Html.HiddenFor(m => m.Id)
 
     <div class="tab-content mt-4" id="droitForm">
@@ -321,3 +321,29 @@
         </div>
     </div>
 </form>
+
+@section Scripts {
+    <script>
+        const form = document.getElementById('droitMultiPartForm');
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+        
+            const form = e.target;
+            const formData = new FormData(form);
+            const data = {};
+            
+            for (const [key, value] of formData) {
+                if (value === '' || value == null) continue;
+                data[key] = data[key]
+                    ? [].concat(data[key], value)
+                    : value;
+            }
+            
+            fetch("/Droit/Save", { 
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(data)
+            });
+        });
+</script>
+}

--- a/backoffice/tests/Converters/FlexibleBooleanConverterTests.cs
+++ b/backoffice/tests/Converters/FlexibleBooleanConverterTests.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+using Droits.Converters;
+using Xunit;
+
+namespace Droits.Tests.Converters;
+
+public class FlexibleBooleanConverterTests
+{
+    private readonly JsonSerializerOptions _options = new()
+    {
+        Converters =
+        {
+            new FlexibleBooleanConverter(),
+            new FlexibleNullableBooleanConverter()
+        }
+    };
+
+
+    [Theory]
+    [InlineData("""
+                "true"
+                """, true)]
+    [InlineData("""
+                "false"
+                """, false)]
+    [InlineData("""
+                "True"
+                """, true)]
+    [InlineData("""
+                "False"
+                """, false)]
+    [InlineData("""
+                "   "
+                """, false)]
+    [InlineData("""
+                ""
+                """, false)]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    public void CanDeserialize_Bool(string json, bool expected)
+    {
+        var result = JsonSerializer.Deserialize<bool>(json, _options);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("""
+                "true"
+                """, true)]
+    [InlineData("""
+                "false"
+                """, false)]
+    [InlineData("""
+                "   "
+                """, null)]
+    [InlineData("""
+                ""
+                """, null)]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    public void CanDeserialize_NullableBool(string json, bool? expected)
+    {
+        var result = JsonSerializer.Deserialize<bool?>(json, _options);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void CanSerialize_Bool_True()
+    {
+        var json = JsonSerializer.Serialize(true, _options);
+        Assert.Equal("true", json);
+    }
+
+    [Fact]
+    public void CanSerialize_NullableBool_Null()
+    {
+        var json = JsonSerializer.Serialize<bool?>(null, _options);
+        Assert.Equal("null", json);
+    }
+}


### PR DESCRIPTION
## Context
<img width="1049" height="134" alt="image" src="https://github.com/user-attachments/assets/8500c5c7-6c57-4f05-a8d2-a2cd43b9ec54" />

This happens when the number of form keys (fields) posted in an HTTP request exceeds the default FormOptions.ValueCountLimit of 1024. This is a security safeguard to protect against overly large or malicious form submissions. The impact is not being able to save large forms using bulk import.

## Changes in this PR
- refactor the form to send as JSON