### PR TITLE
chore: Add coverage script. Gitignore coverage folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ obj/*
 stryker.log
 StrykerOutput
 */reports/mutation
+
+
+# Test coverage
+*coverage*

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -12,7 +12,8 @@
     "dev": "cross-env NODE_ENV=development concurrently \"nodemon -r esm start.js\" \"npm run watch\"",
     "local": "cross-env NODE_ENV=production concurrently \"nodemon -r esm start.js\" \"npm run watch\"",
     "prod": "cross-env NODE_ENV=production concurrently \"node -r esm start.js\"",
-    "test": "jest --detectOpenHandles"
+    "test": "jest --detectOpenHandles",
+    "test:coverage": "jest --coverage --detectOpenHandles"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds a test script to check coverage and gitignores the ensuing coverage folder

Usage:
- cd into the `webapp` folder
- run `npm run test:coverage`