### PR TITLE
fix: remove redundant code

### DIFF
--- a/webapp/utilities/matchRoutes.js
+++ b/webapp/utilities/matchRoutes.js
@@ -1,19 +1,10 @@
- // Try to match a request to a template, for example a request for /test
+// Try to match a request to a template, for example a request for /test
 // would look for /app/views/test.html
 // and /app/views/test/index.html
- const path = require('path');
- const fs = require('fs');
- const ROOT_VIEWS = path.resolve(__dirname, 'views/pages');
+
 function renderPath(path, res, next) {
-  const resolvedPath = path.resolve(ROOT_VIEWS, viewPath);
-  if (!resolvedPath.startsWith(ROOT_VIEWS)) {
-    res.status(403).send("Forbidden");
-    return;
-  }
-  const relativeView = path.relative(path.resolve(__dirname, 'views'), resolvedPath);
-  
   // Try to render the path
-  res.render(relativeView, function (error, html) {
+  res.render(path, function (error, html) {
     if (!error) {
       // Success - send the response
       res.set({ 'Content-type': 'text/html; charset=utf-8' });

--- a/webapp/utilities/matchRoutes.test.js
+++ b/webapp/utilities/matchRoutes.test.js
@@ -3,9 +3,8 @@ import app from "../server";
 
 describe('User can visit the page', () => {
     it('should display the correct page with HTML content', async () => {
-            const response = await request(app).get('/portal/start');
-            expect(response.statusCode).toBe(200);
-            
+        const response = await request(app).get('/portal/start');
+        expect(response.statusCode).toBe(200);
     });
 });
             


### PR DESCRIPTION
This code does not work and is not needed as the path is not a user provided value. Other paths return 404.