### PR TITLE
fix: amend minimum quantity for wreck reporting to 1 to match backoffice

### DIFF
--- a/backoffice/src/Data/Mappers/Imports/WreckMaterialRowDTOMappingProfile.cs
+++ b/backoffice/src/Data/Mappers/Imports/WreckMaterialRowDTOMappingProfile.cs
@@ -14,7 +14,7 @@ namespace Droits.Data.Mappers.Imports
                 .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name))
                 .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description))
                 .ForMember(dest => dest.Quantity,
-                    opt => opt.MapFrom(src => src.Quantity != null ? int.Parse(src.Quantity) : 0))
+                    opt => opt.MapFrom(src => src.Quantity != null ? int.Parse(src.Quantity) : 1))
                 .ForMember(dest => dest.SalvorValuation,
                     opt => opt.MapFrom(src => src.SalvorValuation.AsDouble()))
                 .ForMember(dest => dest.ReceiverValuation,

--- a/backoffice/src/Data/Mappers/Submission/WreckMaterialMappingProfile.cs
+++ b/backoffice/src/Data/Mappers/Submission/WreckMaterialMappingProfile.cs
@@ -12,7 +12,7 @@ namespace Droits.Data.Mappers.Submission
             CreateMap<SubmittedWreckMaterialDto, WreckMaterial>()
                 .ForMember(dest => dest.DroitId, opt => opt.MapFrom(src => src.DroitId))
                 .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name != null ? src.Name.ValueOrEmpty() : string.Empty))
-                .ForMember(dest => dest.Quantity, opt => opt.MapFrom(src => src.Quantity!= null? int.Parse(src.Quantity): 0))
+                .ForMember(dest => dest.Quantity, opt => opt.MapFrom(src => src.Quantity!= null? int.Parse(src.Quantity): 1))
                 .ForMember(dest => dest.SalvorValuation, opt => opt.MapFrom(src => src.Value ?? 0.0d))
                 .ForMember(dest => dest.ValueKnown, opt => opt.MapFrom(src => src.ValueKnown.AsBoolean()))
                 .ForPath(dest => dest.StorageAddress.Line1, opt => opt.MapFrom(src => src.AddressDetails != null ? src.AddressDetails.AddressLine1.ValueOrEmpty() : string.Empty))

--- a/backoffice/tests/UnitTests/Data/Mappers/Import/WreckMaterialRowDTOMappingProfileUnitTests.cs
+++ b/backoffice/tests/UnitTests/Data/Mappers/Import/WreckMaterialRowDTOMappingProfileUnitTests.cs
@@ -145,4 +145,20 @@ public class WreckMaterialRowDtoMappingProfileUnitTests
         
 
     }
+	[Fact]
+	public void TestMappingWithNullQuantity_WMRowDtoToWreckMaterialForm_ReturnsOne()
+	{
+		// Assemble 
+		var rowDto = new WMRowDto()
+		{
+			Name = "Test",
+			Description = "This is a test",
+			Quantity = null
+		};
+		// Act
+		var wreckMaterialForm = _mapper.Map<WreckMaterialForm>(rowDto);
+
+		// Assert
+		Assert.Equal(1, wreckMaterialForm.Quantity);
+	}
 }

--- a/backoffice/tests/UnitTests/Data/Mappers/Submission/WreckMaterialMappingProfileUnitTests.cs
+++ b/backoffice/tests/UnitTests/Data/Mappers/Submission/WreckMaterialMappingProfileUnitTests.cs
@@ -72,7 +72,7 @@ public class WreckMaterialMappingProfileTests
             
         // Assert
         Assert.Equal(string.Empty, wreckMaterial.Name);
-        Assert.Equal(0, wreckMaterial.Quantity);
+        Assert.Equal(1, wreckMaterial.Quantity);
         Assert.Equal(0.0d, wreckMaterial.SalvorValuation);
         Assert.False(wreckMaterial.ValueKnown);
         Assert.Equal(string.Empty, wreckMaterial.StorageAddress.Line1);

--- a/webapp/api/routes/report/property-bulk.js
+++ b/webapp/api/routes/report/property-bulk.js
@@ -156,6 +156,10 @@ export default function (app) {
             err.text = "The selected file contains invalid postcode values. Please enter postcodes in the correct format, for example E1 6AN";
             resolve();
           }
+	  else if (col === 'Quantity' && parseInt(currentRow[col]) < 1){
+            err.text = "The selected file contains a quantity of 0 or less. Quantity must be at least 1 for each item.";
+		  resolve();
+	  }
         }
       }
       resolve();

--- a/webapp/api/routes/report/property-form.js
+++ b/webapp/api/routes/report/property-form.js
@@ -73,7 +73,7 @@ export default function (app) {
         .exists()
         .escape()
         .isInt({ min:1 })
-        .withMessage('Enter a number')
+        .withMessage('Enter a number greater than 0')
         .not()
         .isEmpty()
         .withMessage(

--- a/webapp/api/routes/report/property-form.js
+++ b/webapp/api/routes/report/property-form.js
@@ -72,7 +72,7 @@ export default function (app) {
       await body('property' + '[' + propertyID + '][quantity]')
         .exists()
         .escape()
-        .isNumeric()
+        .isInt({ min:1 })
         .withMessage('Enter a number')
         .not()
         .isEmpty()

--- a/webapp/app/views/report/property-form.html
+++ b/webapp/app/views/report/property-form.html
@@ -55,6 +55,7 @@
           name: propertyNamePrefix + "[quantity]",
           value: data[propertyName][propertyID]["quantity"],
           classes: "govuk-input--width-3",
+	  attributes: { min: "1", type: "number" },
           errorMessage: errors["property." + propertyID + ".quantity"]
         }) }}
 


### PR DESCRIPTION
This was raised off the back of MCABAND-272 to ensure 1 wreck item is the minimum.

It contains changes across four files, where I could find references to the quantity inputted. Backoffice already enforces a minimum of 1 item when editing, this PR aims to replicate this behaviour across the frontend.