### PR TITLE
chore: Add logging around wreck materials images (MCABAND-285)

### DIFF
--- a/webapp/api/routes/report/check-your-answers.js
+++ b/webapp/api/routes/report/check-your-answers.js
@@ -96,11 +96,14 @@ export default function (app) {
         for (const prop in sd['property']) {
           if (sd['property'].hasOwnProperty(prop)) {
             const innerObj = sd['property'][prop];
+            const uploadsPath = '../../../uploads/';
+            console.log(`Resolving wreck material file path for ${__dirname} ${uploadsPath} ${innerObj.image}`);
             const filePath = path.resolve(
               __dirname,
-              '../../../uploads/',
+              uploadsPath,
               innerObj.image
             );
+            console.log(`Wreck material file path is ${filePath}`);
 
             try {
               const imageData = await fs.promises.readFile(filePath, 'base64');
@@ -117,6 +120,7 @@ export default function (app) {
               data['wreck-materials'].push(innerObj);
             } catch (error) {
               console.error('Error reading file:', error);
+              console.error('Full file read error object:', JSON.stringify(error));
               data['wreck-materials'].push(innerObj);
             }
           }

--- a/webapp/api/routes/report/check-your-answers.js
+++ b/webapp/api/routes/report/check-your-answers.js
@@ -97,7 +97,7 @@ export default function (app) {
           if (sd['property'].hasOwnProperty(prop)) {
             const innerObj = sd['property'][prop];
             const uploadsPath = '../../../uploads/';
-            console.log(`Resolving wreck material file path for ${__dirname} ${uploadsPath} ${innerObj.image}`);
+            console.log(`Resolving wreck material file path for '${__dirname}' '${uploadsPath}' '${innerObj.image}'`);
             const filePath = path.resolve(
               __dirname,
               uploadsPath,

--- a/webapp/api/routes/report/check-your-answers.js
+++ b/webapp/api/routes/report/check-your-answers.js
@@ -121,6 +121,7 @@ export default function (app) {
             } catch (error) {
               console.error('Error reading file:', error);
               console.error('Full file read error object:', JSON.stringify(error));
+              // Todo: If it didn't manage to read the image file, the post to the API will fail. We need to decide how we want to handle this possibility
               data['wreck-materials'].push(innerObj);
             }
           }


### PR DESCRIPTION
We found an EISDIR: illegal operation on a directory, read errno: -21 while investigating MCABAND-285.

There is no information in the logs about the file it would have been trying to read, so it's hard to figure out how to replicate the error and fix it.

This pull request adds logging to aid with this in the future.