### PR TITLE
ci: Validate pull request title

### DIFF
--- a/.github/workflows/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/.github/workflows/pull-request-checks.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - synchronize
+  workflow_dispatch: 
 
 permissions:
   pull-requests: read

--- a/.github/workflows/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,20 @@
+name: "Pull request checks"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate pull request title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/.github/workflows/pull-request-checks.yml
@@ -1,13 +1,11 @@
 name: "Pull request checks"
 
 on:
-  push:
   pull_request:
     types:
       - opened
       - edited
       - synchronize
-  workflow_dispatch: 
 
 permissions:
   pull-requests: read

--- a/.github/workflows/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/.github/workflows/pull-request-checks.yml
@@ -1,6 +1,7 @@
 name: "Pull request checks"
 
 on:
+  push:
   pull_request:
     types:
       - opened


### PR DESCRIPTION
Should enforce use of conventional commit messages in the pull request title.

As discussed with @WillFortMadeTech last week.

I don't think it will run until it's in the main branch, but I'm fairly confident it will be fine having used it previously on other projects.