### PR TITLE
ci: Allow rerunning the deployment pipelines MCABAND-291

### DIFF
--- a/.github/workflows/pipeline-dev.yml
+++ b/.github/workflows/pipeline-dev.yml
@@ -1,4 +1,4 @@
-name: Development pipeline
+name: Deploy Development
 
 permissions:
   contents: read

--- a/.github/workflows/pipeline-prod.yml
+++ b/.github/workflows/pipeline-prod.yml
@@ -1,4 +1,4 @@
-name: Production pipeline
+name: Deploy Production
 
 permissions:
   contents: read

--- a/.github/workflows/pipeline-prod.yml
+++ b/.github/workflows/pipeline-prod.yml
@@ -9,6 +9,12 @@ on:
   release:
     types:
       - released
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Image tag to deploy (if you need this to rerun a previous release, get it from that pipeline run''s "Deploy > Set up job > Inputs > image_tag")'
+        required: true
+        type: string
 
 jobs:
   run_pipeline:
@@ -17,7 +23,7 @@ jobs:
     with:
       environment: production
       terraform_workspace: production
-      image_tag: ${{ github.sha }}
+      image_tag: ${{ inputs.image_tag || github.sha }}
     secrets:
       alerts_email: ${{ secrets.ALERTS_EMAIL }}
       alert_pagerduty_integration_url: ${{ secrets.ALERT_PAGERDUTY_INTEGRATION_URL }}

--- a/.github/workflows/pipeline-staging.yml
+++ b/.github/workflows/pipeline-staging.yml
@@ -1,4 +1,4 @@
-name: Staging pipeline
+name: Deploy Staging
 
 permissions:
   contents: read

--- a/.github/workflows/pipeline-staging.yml
+++ b/.github/workflows/pipeline-staging.yml
@@ -9,6 +9,12 @@ on:
   release:
     types:
       - prereleased
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Image tag to deploy (if you need this to rerun a previous release, get it from that pipeline run''s "Deploy > Set up job > Inputs > image_tag")'
+        required: true
+        type: string
 
 jobs:
   run_pipeline:
@@ -17,7 +23,7 @@ jobs:
     with:
       environment: staging
       terraform_workspace: staging
-      image_tag: ${{ github.sha }}
+      image_tag: ${{ inputs.image_tag || github.sha }}
     secrets:
       alerts_email: ${{ secrets.ALERTS_EMAIL }}
       alert_pagerduty_integration_url: ${{ secrets.ALERT_PAGERDUTY_INTEGRATION_URL }}


### PR DESCRIPTION
Also include renaming the pipelines so that it's more obvious which they are from the GitHub Action navigation.