### PR TITLE
ci: Correct cooldown for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,9 +34,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
 
   - package-ecosystem: "docker"
     directories:
@@ -46,9 +43,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -56,6 +50,3 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3


### PR DESCRIPTION
The semantic version options don't work with the terraform, docker and github-actions  ecosystems.