### PR TITLE
docs: initial smoke tests amendments

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ After deploying:
 
 - **Web App**
   - Check the healthcheck endpoint - It should say "OK"
+  - Go to the AWS environment, ECS, DROITS cluster, and confirm that the new task for "droits-cluster", "webapp" is running with a "healthy" state. [AWS Accounts](https://mcaconsole.awsapps.com/start/#/?tab=accounts).
   - Check the "Report Wreck Material" home page loads
     - Initial pages are currently quite different between Dev/Staging and Production
       - Staging * Dev


### PR DESCRIPTION
This is an addition to the (manual) droits smoke tests whilst we ensure the best solution for deployment smoke testing is chosen. 

This serves as a reminder to ensure that in al deployments, the health of the container in AWS is confirmed, and the logs are reviewed.