### PR TITLE
fix: added circuit breaker to keep healthy deployments

### DIFF
--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -44,6 +44,10 @@ resource "aws_ecs_service" "service" {
   health_check_grace_period_seconds = var.health_check_grace_period
   # wait_for_steady_state = true
 
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
 
   network_configuration {
     security_groups  = var.security_groups


### PR DESCRIPTION
This is a terraform change which will ensure that the latest healthy container is always being used:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#deployment_circuit_breaker

Rollback uses the latest successful deployment. 