### PR TITLE
fix: added return on redirect

### DIFF
--- a/webapp/api/routes/report/property-form-address.js
+++ b/webapp/api/routes/report/property-form-address.js
@@ -13,7 +13,7 @@ export default function (app) {
       propertyID = rawPropertyID;
       propertyItem = property[propertyID];
     } else {
-      res.redirect('/report/property-summary');
+      return res.redirect('/report/property-summary');
     }
 
     res.render('report/property-form-address', {

--- a/webapp/api/routes/report/property-form-image.js
+++ b/webapp/api/routes/report/property-form-image.js
@@ -13,7 +13,7 @@ export default function (app) {
       propertyID = rawPropertyID;
       propertyItem = property[propertyID];
     } else {
-      res.redirect('/report/property-summary');
+      return res.redirect('/report/property-summary');
     }
 
     res.render('report/property-form-image', {

--- a/webapp/api/routes/report/property-summary.js
+++ b/webapp/api/routes/report/property-summary.js
@@ -69,7 +69,7 @@ export default function (app) {
     if (property[rawPropertyID] !== undefined) {
       propertyItem = property[rawPropertyID];
     } else {
-      res.redirect('/report/property-summary');
+      return res.redirect('/report/property-summary');
     }
 
     res.render('report/property-delete', {


### PR DESCRIPTION
This is off the back of a container restart we had yesterday for Droits which is due to a "double response".
Throwing two responses to one request throws the error, and uncaught this kills the process.

property-form.js already had this return set up:
<img width="700" height="150" alt="image" src="https://github.com/user-attachments/assets/9c07f42b-c2ef-4345-b2b7-74bf03af90ea" />

Therefore it seems like this is something that has been observed before, but the surface area for this error wasn't covered. 

This has been tested locally. Testing currently in dev and providing all is working as expected we can move to staging and prod shortly.