### PR TITLE
feat: adding smoke tests for the droits service

### DIFF
--- a/.github/workflows/_reusable-smoke-tests.yml
+++ b/.github/workflows/_reusable-smoke-tests.yml
@@ -6,6 +6,15 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      environment:
+        description: The environment to run against (development/staging/production)
+        required: true
+        type: string
+      base_url:
+        description: The webapp URL to test
+        required: true
+        type: string
     secrets:
       aws_role_arn:
         description: Role used for waiting for ECS to deploy successfully.
@@ -15,6 +24,7 @@ jobs:
   smoke_tests:
     name: Smoke tests
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
 
     steps:
       - uses: actions/checkout@v6
@@ -32,14 +42,14 @@ jobs:
       - name: Wait for ECS services to deploy
         run: aws ecs wait services-stable --cluster droits-cluster --services webapp backoffice
 
-      - name: Run Cypress smoke tests against production
+      - name: Run Cypress smoke tests
         uses: cypress-io/github-action@v6
         with:
           working-directory: tests
           browser: chrome
           spec: cypress/e2e/smoke/*.cy.js
         env:
-          CYPRESS_BASE_URL: https://report-wreck-material.service.gov.uk
+          CYPRESS_BASE_URL: ${{ inputs.base_url }}
 
       - uses: actions/upload-artifact@v6
         if: failure()

--- a/.github/workflows/_reusable-smoke-tests.yml
+++ b/.github/workflows/_reusable-smoke-tests.yml
@@ -50,6 +50,7 @@ jobs:
           spec: cypress/e2e/smoke/*.cy.js
         env:
           CYPRESS_BASE_URL: ${{ inputs.base_url }}
+          CYPRESS_ENVIRONMENT: ${{ inputs.environment }}
 
       - uses: actions/upload-artifact@v6
         if: failure()

--- a/.github/workflows/_reusable-smoke-tests.yml
+++ b/.github/workflows/_reusable-smoke-tests.yml
@@ -1,0 +1,34 @@
+name: "[reusable] Smoke tests"
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+
+jobs:
+  smoke_tests:
+    name: Smoke tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22.17.0"
+
+      - name: Run Cypress smoke tests against production
+        uses: cypress-io/github-action@v6
+        with:
+          working-directory: tests
+          browser: chrome
+          spec: cypress/e2e/smoke/*.cy.js
+        env:
+          CYPRESS_BASE_URL: https://report-wreck-material.service.gov.uk
+
+      - uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: smoke-test-screenshots
+          path: tests/cypress/screenshots/

--- a/.github/workflows/_reusable-smoke-tests.yml
+++ b/.github/workflows/_reusable-smoke-tests.yml
@@ -2,9 +2,14 @@ name: "[reusable] Smoke tests"
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   workflow_call:
+    secrets:
+      aws_role_arn:
+        description: Role used for waiting for ECS to deploy successfully.
+        required: true
 
 jobs:
   smoke_tests:
@@ -17,6 +22,15 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "22.17.0"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.aws_role_arn }}
+          aws-region: eu-west-2
+
+      - name: Wait for ECS services to deploy
+        run: aws ecs wait services-stable --cluster droits-cluster --services webapp backoffice
 
       - name: Run Cypress smoke tests against production
         uses: cypress-io/github-action@v6

--- a/.github/workflows/pipeline-dev.yml
+++ b/.github/workflows/pipeline-dev.yml
@@ -32,3 +32,13 @@ jobs:
       testing_webapp_env_file: ${{ secrets.TESTING_WEBAPP_ENV_FILE }}
       webapp_env_file: ${{ secrets.WEBAPP_ENV_FILE }}
       webapp_repository_name: ${{ secrets.WEBAPP_ECR_REPOSITORY_NAME }}
+
+  smoke_tests:
+    name: Run smoke tests
+    needs: [run_pipeline]
+    uses: ./.github/workflows/_reusable-smoke-tests.yml
+    with:
+      environment: development
+      base_url: https://dev.report-wreck-material.service.gov.uk
+    secrets:
+      aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/pipeline-prod.yml
+++ b/.github/workflows/pipeline-prod.yml
@@ -37,3 +37,8 @@ jobs:
       testing_webapp_env_file: ${{ secrets.TESTING_WEBAPP_ENV_FILE }}
       webapp_env_file: ${{ secrets.WEBAPP_ENV_FILE }}
       webapp_repository_name: ${{ secrets.WEBAPP_ECR_REPOSITORY_NAME }}
+
+  smoke_tests:
+    name: Run smoke tests
+    needs: [run_pipeline]
+    uses: ./.github/workflows/_reusable-smoke-tests.yml

--- a/.github/workflows/pipeline-prod.yml
+++ b/.github/workflows/pipeline-prod.yml
@@ -42,3 +42,5 @@ jobs:
     name: Run smoke tests
     needs: [run_pipeline]
     uses: ./.github/workflows/_reusable-smoke-tests.yml
+    secrets:
+      aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/pipeline-prod.yml
+++ b/.github/workflows/pipeline-prod.yml
@@ -42,5 +42,8 @@ jobs:
     name: Run smoke tests
     needs: [run_pipeline]
     uses: ./.github/workflows/_reusable-smoke-tests.yml
+    with:
+      environment: production
+      base_url: https://report-wreck-material.service.gov.uk
     secrets:
       aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/pipeline-staging.yml
+++ b/.github/workflows/pipeline-staging.yml
@@ -37,3 +37,13 @@ jobs:
       testing_webapp_env_file: ${{ secrets.TESTING_WEBAPP_ENV_FILE }}
       webapp_env_file: ${{ secrets.WEBAPP_ENV_FILE }}
       webapp_repository_name: ${{ secrets.WEBAPP_ECR_REPOSITORY_NAME }}
+
+  smoke_tests:
+    name: Run smoke tests
+    needs: [run_pipeline]
+    uses: ./.github/workflows/_reusable-smoke-tests.yml
+    with:
+      environment: staging
+      base_url: https://staging.report-wreck-material.service.gov.uk
+    secrets:
+      aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}

--- a/README.md
+++ b/README.md
@@ -103,29 +103,18 @@ These are manual at the moment. Writing them down is the first step on the journ
 After deploying:
 
 - **Web App**
-  - Check the healthcheck endpoint - It should say "OK"
   - Check the "Report Wreck Material" home page loads
     - Initial pages are currently quite different between Dev/Staging and Production
       - Staging * Dev
         - Check the three help links top right work
-        - Click through to "Report Wreck Material"
-        - Check the "required format" links triggers download of the CSV template
         - Check the "contact the Receiver of Wreck" link works
       - Production
         - Check the three "Contents" links work
         - Click through to "Report Wreck Material"
-    - Click "Start now"
-      - When asked, use the email `<firstname>.<lastname>+<YYYY-MM-DD>@<domain>.<tld>` which, for Gmail at least, will be sent to `<firstname>.<lastname>@<domain>.<tld>`
-      - Check you can make it all the way through to the point of submission (It will say "Accept and send" under the "Declaration by finder"
-      - **Dev & Staging Only**
-        - Click "Accept and send" to send the report
-        - On the confirmation page check that the "Print a copy of your report" button works
-        - Check that the "Check report status" button takes you to the "Check the status of wreck material you have reported" page that includes the "Sign in" button
   - Return to the home page
     - Staging * Dev
       - Click the "Check the status of wreck material reported" link
       - Check you are on the "Check the status of wreck material you have reported"
-        - Check the "submitting a report" link return you to the "Report Wreck Material" page
         - Use the browser's back button to return to the "Check the status of wreck material you have reported"
       - Click on the "create an account" link and check you are on the "Sign up" page
         - **Dev & Staging Only** (keeping this because we want to get the environments aligned in future)

--- a/tests/cypress/e2e/smoke/csv-template-downloads.cy.js
+++ b/tests/cypress/e2e/smoke/csv-template-downloads.cy.js
@@ -1,0 +1,18 @@
+describe('Smoke test - bulk upload CSV template', () => {
+  const templatePath = '/assets/downloads/ROW-bulk-upload-template.csv'
+
+  it('links to the CSV template from the report start page', () => {
+    cy.visit('/report/start')
+    cy.get(`a[href="${templatePath}"]`)
+      .should('be.visible')
+      .and('contain.text', 'required format')
+  })
+
+  it('serves the CSV template for download', () => {
+    cy.request(templatePath).then((response) => {
+      expect(response.status).to.eq(200)
+      expect(response.headers['content-type']).to.include('text/csv')
+      expect(response.body).to.not.be.empty
+    })
+  })
+})

--- a/tests/cypress/e2e/smoke/healthcheck.cy.js
+++ b/tests/cypress/e2e/smoke/healthcheck.cy.js
@@ -1,0 +1,8 @@
+describe('Smoke test - healthcheck', () => {
+  it('returns OK from the web app healthcheck endpoint', () => {
+    cy.request('/health').then((response) => {
+      expect(response.status).to.eq(200)
+      expect(response.body).to.eq('OK')
+    })
+  })
+})

--- a/tests/cypress/e2e/smoke/home-page-loads.cy.js
+++ b/tests/cypress/e2e/smoke/home-page-loads.cy.js
@@ -1,0 +1,17 @@
+describe('Smoke test - home page', () => {
+  const devOrStaging = ['development', 'staging'].includes(Cypress.env('ENVIRONMENT'))
+
+  it('loads the home page and links through to the report start page', function () {
+    if (!devOrStaging) {
+      this.skip()
+    }
+
+    cy.visit('/')
+    cy.contains('h1', 'Report Wreck Material').should('be.visible')
+
+    cy.contains('a', 'Report wreck material').click()
+
+    cy.url().should('include', '/report/start')
+    cy.contains('.govuk-button', 'Start now').should('be.visible')
+  })
+})

--- a/tests/cypress/e2e/smoke/homepage-loads.cy.js
+++ b/tests/cypress/e2e/smoke/homepage-loads.cy.js
@@ -1,0 +1,13 @@
+describe('Smoke test', () => {
+  it('loads the report start page', () => {
+    cy.visit('/report/start')
+    cy.get('.govuk-button').should('be.visible')
+  })
+
+  it('loads the first report question page', () => {
+    cy.visit('/report/removed-property-check')
+    cy.contains('h1', 'Have you removed the wreck material').should('be.visible')
+    cy.get('#removed-property').should('exist')
+    cy.get('#removed-property-2').should('exist')
+  })
+})

--- a/tests/cypress/e2e/smoke/portal-start-loads.cy.js
+++ b/tests/cypress/e2e/smoke/portal-start-loads.cy.js
@@ -1,0 +1,11 @@
+describe('Smoke test - portal start page', () => {
+  it('loads the check report status page with a Sign in button', () => {
+    cy.visit('/portal/start')
+
+    cy.contains('h1', 'Check the status of wreck material you have reported').should('be.visible')
+
+    cy.get('#signIn')
+      .should('be.visible')
+      .and('contain.text', 'Sign in')
+  })
+})

--- a/tests/cypress/e2e/smoke/portal-start-loads.cy.js
+++ b/tests/cypress/e2e/smoke/portal-start-loads.cy.js
@@ -8,4 +8,13 @@ describe('Smoke test - portal start page', () => {
       .should('be.visible')
       .and('contain.text', 'Sign in')
   })
+
+  it('returns to the report start page via the "submitting a report" link', () => {
+    cy.visit('/portal/start')
+
+    cy.contains('a', 'submitting a report').click()
+
+    cy.url().should('include', '/report/start')
+    cy.contains('.govuk-button', 'Start now').should('be.visible')
+  })
 })

--- a/tests/cypress/e2e/smoke/report-journey.cy.js
+++ b/tests/cypress/e2e/smoke/report-journey.cy.js
@@ -72,5 +72,11 @@ describe('Smoke test - report a wreck journey', () => {
 
     cy.contains('.govuk-panel__title', 'Report submitted', { timeout: 60000 }).should('be.visible')
     cy.get('.govuk-panel__body strong').invoke('text').should('not.be.empty')
+
+    cy.contains('.govuk-button', 'Print a copy of your report').should('be.visible')
+
+    cy.contains('.govuk-button', 'Check report status').click()
+    cy.url().should('include', '/portal/start')
+    cy.get('#signIn').should('be.visible')
   })
 })

--- a/tests/cypress/e2e/smoke/report-journey.cy.js
+++ b/tests/cypress/e2e/smoke/report-journey.cy.js
@@ -1,0 +1,76 @@
+describe('Smoke test - report a wreck journey', () => {
+  const submittableEnvironments = ['development', 'staging']
+  const canSubmit = submittableEnvironments.includes(Cypress.env('ENVIRONMENT'))
+
+  it('completes a report through to the declaration', () => {
+    cy.visit('/report/start')
+    cy.contains('.govuk-button', 'Start now').click()
+
+    cy.get('#removed-property').check() // Yes
+    cy.clickContinue()
+
+    cy.get('#wreck-find-date-day').clear().type('15')
+    cy.get('#wreck-find-date-month').clear().type('08')
+    cy.get('#wreck-find-date-year').clear().type('2025')
+    cy.clickContinue()
+
+    const stamp = new Date().toISOString().slice(0, 10)
+    cy.get('#full-name').clear().type('ROW Smoke Test')
+    cy.get('#email').clear().type(`row.smoke.test+${stamp}@example.com`)
+    cy.get('#address-line-1').clear().type('48 Street')
+    cy.get('#address-town').clear().type('London')
+    cy.get('#address-county').clear().type('Surrey')
+    cy.get('#address-postcode').clear().type('E17 2MD')
+    cy.clickContinue()
+
+    cy.get('#known-wreck-2').check() // No
+    cy.clickContinue()
+
+    // Select "Sea shore" as salvage location
+    cy.get('#removed-from-4').check()
+    cy.clickContinue()
+
+    // Select location method: Decimal degrees
+    cy.get('#location-type').check()
+    // Enter coordinates
+    cy.get('#location-latitude-decimal').type('50.8225')
+    cy.get('#location-longitude-decimal').type('-0.1372')
+    cy.clickContinue()
+
+    cy.contains('Add your first item').click()
+
+    cy.get('#property\\.i0\\.description').clear().type('Ship timber')
+    cy.get('#property\\.i0\\.quantity').clear().type('1')
+    cy.get('#value-known-2').check()
+    cy.clickContinue()
+
+    cy.get('#property-image').click()
+    cy.get('input[type="file"]').selectFile('cypress/fixtures/test.jpeg', { force: true })
+    cy.get('.photo-upload__button').click()
+    cy.get('.govuk-button--continue').click()
+
+    //  where the wreck is stored
+    cy.get('#property-i0-storage-address').check()
+    cy.clickContinue()
+
+    // shows declaration page and asks if I wish to claim award
+    cy.get('#propertyDeclaration').check()
+    cy.get('.form > .govuk-button').click()
+
+    cy.get('#claim-salvage-2').check()
+    cy.get('.govuk-button').click()
+
+    cy.url().should('include', '/report/check-your-answers')
+    cy.contains('.govuk-button', 'Accept and send').should('be.visible')
+
+    if (!canSubmit) {
+      return
+    }
+
+    cy.get('#property-declaration').check()
+    cy.contains('.govuk-button', 'Accept and send').click()
+
+    cy.contains('.govuk-panel__title', 'Report submitted', { timeout: 60000 }).should('be.visible')
+    cy.get('.govuk-panel__body strong').invoke('text').should('not.be.empty')
+  })
+})


### PR DESCRIPTION
This (draft) PR is starting as a PoC for smoke tests for the droits service. It will wait for a successful deployment and then run the homepage-loads smoke test. 

Once the PoC has been tested, is documented and up to standard, we can start increasing testing surface area.